### PR TITLE
update for loop to be more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## Show this help message.
 
 .PHONY: test
 test: ## Run unit tests.
-	go test -race -coverprofile=coverage.out `go list ./... | grep -v 'examples'`
+	go test -race -shuffle=on -count=1 -coverprofile=coverage.out `go list ./... | grep -v 'examples'`
 
 .PHONY: testx
 testx: ## Run unit tests multiple times.

--- a/internal/seq/chan_test.go
+++ b/internal/seq/chan_test.go
@@ -194,14 +194,10 @@ func TestFromChanEarlyCancelFromGenerator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	in := make(chan int)
+	defer close(in)
 	go func() {
-		defer close(in)
 		for i := range 10 {
-			select {
-			case <-ctx.Done():
-				return
-			case in <- i:
-			}
+			in <- i
 		}
 		cancel()
 	}()

--- a/internal/shard/repartition_test.go
+++ b/internal/shard/repartition_test.go
@@ -252,7 +252,6 @@ func TestRepartitionOneToOneEarlyCancelDuringRepartition(t *testing.T) {
 		require.Equal(t, 0, cap(out))
 		<-sent
 		cancel()
-		//time.Sleep(2 * time.Second)
 		synctest.Wait()
 		var got int
 		for range out {

--- a/scripts/find_bad_coverage
+++ b/scripts/find_bad_coverage
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while true
+do
+  #make test
+  go test -shuffle=on -count=1 -coverprofile=coverage.out `go list ./... | grep -v 'examples'`
+  coverage=$(go tool cover -func=coverage.out | tail -1 | awk '{ print $3; }')
+  [[ $coverage == "100.0%" ]] || exit 0
+done
+

--- a/scripts/open_ubuntu
+++ b/scripts/open_ubuntu
@@ -1,0 +1,9 @@
+#!/bin/zsh
+
+image_name=$(docker images --format json | jq -r '.Repository')
+[[ $image_name == "ubuntu-go" ]] || docker build -f ./scripts/ubuntu.Dockerfile -t ubuntu-go .
+
+docker run -it --rm \
+  -v "$PWD":/work \
+  -w /work \
+  ubuntu-go bash

--- a/scripts/test_from_docker
+++ b/scripts/test_from_docker
@@ -6,7 +6,15 @@ test_command='
 go test -race -coverprofile=coverage.out `go list ./... | grep -v "examples"`
 go tool cover -html=coverage.out -o coverage.html
 '
+# docker run --rm \
+#   -v "$PWD":/work -w /work \
+#   golang:1.25 \
+#   sh -c "${test_command}"
+
+image_name=$(docker images --format json | jq -r '.Repository')
+[[ $image_name == "ubuntu-go" ]] || docker build -f ./scripts/ubuntu.Dockerfile -t ubuntu-go .
+
 docker run --rm \
-  -v "$PWD":/work -w /work \
-  golang:1.25 \
-  sh -c "${test_command}"
+  -v "$PWD":/work \
+  -w /work \
+  ubuntu-go bash -c "${test_command}"

--- a/scripts/test_from_ubuntu
+++ b/scripts/test_from_ubuntu
@@ -4,7 +4,6 @@
 
 test_command='
 go test -race -coverprofile=coverage.out `go list ./... | grep -v "examples"`
-go tool cover -html=coverage.out -o coverage.html
 '
 # docker run --rm \
 #   -v "$PWD":/work -w /work \

--- a/scripts/ubuntu.Dockerfile
+++ b/scripts/ubuntu.Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:latest
+
+ARG GO_VERSION=1.25.1
+ARG TARGETARCH=arm64
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" -o /tmp/go.tgz \
+ && tar -C /usr/local -xzf /tmp/go.tgz \
+ && rm /tmp/go.tgz
+
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/go
+ENV PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+ENV CGO_ENABLED=1
+
+WORKDIR /workspace
+
+RUN go version


### PR DESCRIPTION
- make for loop more robust for repartition loop (allows you to cancel instead of getting stuck waiting to receiving on a channel that hasn't been closed)
- set up test with hard stop
- set up helper scripts to find tests with flakey coverage
- made some tests more deterministic on coverage