### PR TITLE
no longer using scope.Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ go get github.com/jaredmtdev/gather
 
 - Workers: start a worker pool that consumes an input channel and returns an output channel
 - HandlerFunc: handles each job
-- Scope: tools available to a handler (retries, safe go routines, etc)
+- Scope: tools available to a handler (i.e. retries)
 - Middleware: wrap handlers and other middleware
 - Chain: chains multiple middleware
 

--- a/scope.go
+++ b/scope.go
@@ -3,26 +3,21 @@ package gather
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
 // Scope - a per-request utility passed to handlers and middleware.
 type Scope[IN any] struct {
-	reenqueue   func(IN)
-	willRetry   bool
-	retryClosed atomic.Bool
-	once        *sync.Once
-	wgJob       *sync.WaitGroup
+	reenqueue func(IN)
+	willRetry bool
+	once      sync.Once
+	wgJob     *sync.WaitGroup
 }
 
 // RetryAfter - retry the request after "delay" time passes.
 // only one retry can be done at a time for each job.
 // any extra retries will be ignored.
 func (s *Scope[IN]) RetryAfter(ctx context.Context, in IN, delay time.Duration) {
-	if s.retryClosed.Load() {
-		panic("Invalid attempt to retry. Retries can only be executed BEFORE spawning new go routines with scope.Go.")
-	}
 	s.once.Do(func() {
 		s.willRetry = true
 		s.wgJob.Go(func() {
@@ -39,11 +34,4 @@ func (s *Scope[IN]) RetryAfter(ctx context.Context, in IN, delay time.Duration) 
 // Retry - will retry immediately.
 func (s *Scope[IN]) Retry(ctx context.Context, in IN) {
 	s.RetryAfter(ctx, in, 0)
-}
-
-// Go - allow your handler to safely spin up a new go routine (in addition to the worker go routine).
-// the worker will not shut down while this go routine is running.
-func (s *Scope[IN]) Go(f func()) {
-	s.retryClosed.Store(true)
-	s.wgJob.Go(f)
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -3,6 +3,7 @@ package gather_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/jaredmtdev/gather"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestScopeRetry(t *testing.T) {
@@ -213,211 +213,6 @@ func TestScopeWithMultipleRetries(t *testing.T) {
 	assert.Equal(t, int32(23), totalAttempts.Load())
 }
 
-func TestScopeGo(t *testing.T) {
-	ctx := context.Background()
-	counter := atomic.Int32{}
-	handler := gather.HandlerFunc[int, int](func(_ context.Context, in int, scope *gather.Scope[int]) (int, error) {
-		if in == 2 || in == 3 {
-			scope.Go(
-				func() {
-					counter.Add(1)
-				},
-			)
-		}
-		return in * 2, nil
-	})
-
-	var got int
-	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
-		got++
-	}
-	assert.Equal(t, 20, got)
-	assert.Equal(t, int32(2), counter.Load())
-}
-
-func TestScopeGoNested(t *testing.T) {
-	ctx := context.Background()
-	counter := atomic.Int32{}
-	handler := gather.HandlerFunc[int, int](func(_ context.Context, in int, scope *gather.Scope[int]) (int, error) {
-		if in == 2 || in == 3 {
-			scope.Go(
-				func() {
-					counter.Add(1)
-					scope.Go(func() {
-						counter.Add(1)
-					})
-				},
-			)
-		}
-		return in * 2, nil
-	})
-
-	var got int
-	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
-		got++
-	}
-	assert.Equal(t, 20, got)
-	assert.Equal(t, int32(4), counter.Load())
-}
-
-func TestScopeMultipleGo(t *testing.T) {
-	ctx := context.Background()
-	counter := atomic.Int32{}
-	handler := gather.HandlerFunc[int, int](func(_ context.Context, in int, scope *gather.Scope[int]) (int, error) {
-		if in == 2 || in == 3 {
-			for range 3 {
-				scope.Go(
-					func() {
-						counter.Add(1)
-					},
-				)
-			}
-		}
-		return in * 2, nil
-	})
-
-	var got int
-	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
-		got++
-	}
-	assert.Equal(t, 20, got)
-	assert.Equal(t, int32(2*3), counter.Load())
-}
-
-func TestScopeGoWithRetry(t *testing.T) {
-	ctx := context.Background()
-	panicCh := make(chan any, 20)
-
-	handler := gather.HandlerFunc[int, int](func(ctx context.Context, in int, scope *gather.Scope[int]) (int, error) {
-		if in == 2 || in == 3 {
-			scope.Go(
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							panicCh <- r
-						}
-					}()
-					scope.Retry(ctx, in+1)
-				},
-			)
-			return 0, errors.New("oops")
-		}
-		return in * 2, nil
-	})
-
-	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
-	}
-
-	close(panicCh)
-	var actualPanics int
-	for r := range panicCh {
-		assert.Contains(t, r, "Invalid attempt to retry")
-		actualPanics++
-	}
-	assert.Equal(t, 2, actualPanics)
-}
-
-func TestScopeGoThenRetry(t *testing.T) {
-	ctx := context.Background()
-	counter := atomic.Int32{}
-	panicCh := make(chan any, 20)
-
-	handler := gather.HandlerFunc[int, int](func(ctx context.Context, in int, scope *gather.Scope[int]) (int, error) {
-		defer func() {
-			if r := recover(); r != nil {
-				panicCh <- r
-			}
-		}()
-		if in == 2 || in == 3 {
-			scope.Go(
-				func() {
-					counter.Add(1)
-				},
-			)
-			scope.Retry(ctx, in+1)
-			return 0, errors.New("oops")
-		}
-		return in * 2, nil
-	})
-
-	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
-	}
-	close(panicCh)
-	var actualPanics int
-	for r := range panicCh {
-		assert.Contains(t, r, "Invalid attempt to retry")
-		actualPanics++
-	}
-	assert.Equal(t, 2, actualPanics)
-	assert.Equal(t, int32(2), counter.Load())
-}
-
-func TestScopeRetryThenGo(t *testing.T) {
-	ctx := context.Background()
-	totalAttempts := atomic.Int32{}
-	counter := atomic.Int32{}
-
-	handler := gather.HandlerFunc[int, int](func(ctx context.Context, in int, scope *gather.Scope[int]) (int, error) {
-		totalAttempts.Add(1)
-		if in == 2 || in == 3 {
-			scope.Retry(ctx, in+1)
-			scope.Go(func() {
-				counter.Add(1)
-			})
-			return 0, errors.New("invalid number")
-		}
-		return in * 2, nil
-	})
-
-	var got int
-	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
-		got++
-	}
-	assert.Equal(t, 20, got)
-	assert.Equal(t, int32(3), counter.Load())
-	assert.Equal(t, int32(23), totalAttempts.Load())
-}
-
-func TestOrderedWorkersAndScopeRetryThenGo(t *testing.T) {
-	seed := time.Now().UnixNano()
-	synctest.Test(t, func(t *testing.T) {
-		ctx := context.Background()
-		totalAttempts := atomic.Int32{}
-		counter := atomic.Int32{}
-
-		opts := []gather.Opt{
-			gather.WithWorkerSize(5),
-			gather.WithBufferSize(3),
-			gather.WithOrderPreserved(),
-		}
-
-		mw := mwRandomDelay[int, int](seed, 0, time.Second)
-
-		handler := gather.HandlerFunc[int, int](func(ctx context.Context, in int, scope *gather.Scope[int]) (int, error) {
-			totalAttempts.Add(1)
-			if in == 2 || in == 3 {
-				scope.Retry(ctx, in+1)
-				scope.Go(func() {
-					counter.Add(1)
-				})
-				return 0, errors.New("invalid number")
-			}
-			return in * 2, nil
-		})
-
-		var got int
-		for v := range gather.Workers(ctx, gen(ctx, 1000), mw(handler), opts...) {
-			if got != 2 && got != 3 {
-				require.Equal(t, got*2, v)
-			}
-			got++
-		}
-		assert.Equal(t, 1000, got)
-		assert.Equal(t, int32(3), counter.Load())
-		assert.Equal(t, int32(1003), totalAttempts.Load())
-	})
-}
-
 func TestScopeRetryDuringCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -439,4 +234,31 @@ func TestScopeRetryDuringCancellation(t *testing.T) {
 	}
 	assert.LessOrEqual(t, got, 2)
 	assert.LessOrEqual(t, int32(2), totalAttempts.Load())
+}
+
+func TestScopeRetryThenWaitGroupGo(t *testing.T) {
+	ctx := context.Background()
+	totalAttempts := atomic.Int32{}
+	counter := atomic.Int32{}
+	wg := sync.WaitGroup{}
+	handler := gather.HandlerFunc[int, int](func(ctx context.Context, in int, scope *gather.Scope[int]) (int, error) {
+		totalAttempts.Add(1)
+		if in == 2 || in == 3 {
+			scope.Retry(ctx, in+1)
+			wg.Go(func() {
+				counter.Add(1)
+			})
+			return 0, errors.New("invalid number")
+		}
+		return in * 2, nil
+	})
+
+	var got int
+	for range gather.Workers(ctx, gen(ctx, 20), handler, gather.WithWorkerSize(5)) {
+		got++
+	}
+	wg.Wait()
+	assert.Equal(t, 20, got)
+	assert.Equal(t, int32(3), counter.Load())
+	assert.Equal(t, int32(23), totalAttempts.Load())
 }

--- a/workers.go
+++ b/workers.go
@@ -165,7 +165,6 @@ func (ws *workerStation[IN, OUT]) StartWorker(ctx context.Context) {
 		scope := Scope[IN]{
 			reenqueue: ws.buildReenqueueFunc(ctx, jobIn.index),
 			wgJob:     &ws.wgJob,
-			once:      &sync.Once{},
 		}
 
 		res, err := ws.handler(ctx, jobIn.val, &scope)


### PR DESCRIPTION
- remove scope.Go

this functionality was a convenience but I don't believe it can be implemented in a safe way.
Also, it wasn't a necessary feature.