### PR TITLE
Elastic workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ notes.md
 learned.md
 testdata/
 .scripts/
+trace.out

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: ## Run unit tests.
 
 .PHONY: testx
 testx: ## Run unit tests multiple times to catch flakey tests.
-	go test -v -count=1000 `go list ./... | grep -v 'examples'` -failfast -timeout=30s -p 1 -parallel 2
+	go test -v -count=1000 `go list ./... | grep -v 'examples'` -failfast -timeout=40s -p 1 -parallel 2
 
 .PHONY: fuzz
 fuzz: ## Run fuzz tests to try to find edge cases.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ go func(){
 }
 ```
 
+Close the `in` channel when finished sending data.
+Otherwise, cancel the context to stop the worker at any point.
+
 #### 3: Configure and run the worker pool
 
 ```go

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,35 @@
+package gather
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+var (
+	errInvalidWorkerSize     = errors.New("must use at least 1 worker")
+	errInvalidMinWorkerSize  = errors.New("must use at least 0 min workers")
+	errInvalidBufferSize     = errors.New("buffer must be at least 0")
+	errInvalidTTL            = errors.New("ttl must use at least 0 ns")
+	errMinWorkerSizeTooLarge = errors.New("minWorkerSize cannot be larger than workerSize")
+)
+
+func newInvalidWorkerSizeError(workerSize int) error {
+	return fmt.Errorf("%w. workerSize: %v", errInvalidWorkerSize, workerSize)
+}
+
+func newInvalidMinWorkerSizeError(minWorkerSize int) error {
+	return fmt.Errorf("%w. minWorkerSize: %v", errInvalidMinWorkerSize, minWorkerSize)
+}
+
+func newInvalidBufferSizeError(bufferSize int) error {
+	return fmt.Errorf("%w. bufferSize: %v", errInvalidBufferSize, bufferSize)
+}
+
+func newInvalidTTLError(ttl time.Duration) error {
+	return fmt.Errorf("%w. ttlElastic: %v ns", errInvalidTTL, ttl.Nanoseconds())
+}
+
+func newMinWorkerSizeTooLargeError(minWorkerSize, maxWorkerSize int) error {
+	return fmt.Errorf("%w. minWorkerSize: %v workerSize: %v", errMinWorkerSizeTooLarge, minWorkerSize, maxWorkerSize)
+}

--- a/errors.go
+++ b/errors.go
@@ -14,11 +14,11 @@ var (
 	errMinWorkerSizeTooLarge = errors.New("minWorkerSize cannot be larger than workerSize")
 )
 
-func newInvalidWorkerSizeError(workerSize int) error {
+func newInvalidWorkerSizeError(workerSize int64) error {
 	return fmt.Errorf("%w. workerSize: %v", errInvalidWorkerSize, workerSize)
 }
 
-func newInvalidMinWorkerSizeError(minWorkerSize int) error {
+func newInvalidMinWorkerSizeError(minWorkerSize int64) error {
 	return fmt.Errorf("%w. minWorkerSize: %v", errInvalidMinWorkerSize, minWorkerSize)
 }
 
@@ -30,6 +30,6 @@ func newInvalidTTLError(ttl time.Duration) error {
 	return fmt.Errorf("%w. ttlElastic: %v ns", errInvalidTTL, ttl.Nanoseconds())
 }
 
-func newMinWorkerSizeTooLargeError(minWorkerSize, maxWorkerSize int) error {
+func newMinWorkerSizeTooLargeError(minWorkerSize, maxWorkerSize int64) error {
 	return fmt.Errorf("%w. minWorkerSize: %v workerSize: %v", errMinWorkerSizeTooLarge, minWorkerSize, maxWorkerSize)
 }

--- a/errors_internal_test.go
+++ b/errors_internal_test.go
@@ -1,0 +1,54 @@
+package gather
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerOpts(t *testing.T) {
+	testCases := []struct {
+		name        string
+		opts        []Opt
+		expectedErr error
+	}{
+		{
+			name:        "negative buffer",
+			opts:        []Opt{WithBufferSize(-1)},
+			expectedErr: errInvalidBufferSize,
+		},
+		{
+			name:        "zero worker size",
+			opts:        []Opt{WithWorkerSize(0)},
+			expectedErr: errInvalidWorkerSize,
+		},
+		{
+			name:        "min workers larger than max workers",
+			opts:        []Opt{WithWorkerSize(2), WithElasticWorkers(3, time.Millisecond)},
+			expectedErr: errMinWorkerSizeTooLarge,
+		},
+		{
+			name:        "negative min workers",
+			opts:        []Opt{WithElasticWorkers(-1, time.Millisecond)},
+			expectedErr: errInvalidMinWorkerSize,
+		},
+		{
+			name:        "negative ttl",
+			opts:        []Opt{WithElasticWorkers(1, -time.Millisecond)},
+			expectedErr: errInvalidTTL,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := newWorkerOpts(tc.opts).validate()
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/workers.go
+++ b/workers.go
@@ -235,18 +235,16 @@ func (ws *workerStation[IN, OUT]) wgJobFlush() {
 
 func (ws *workerStation[IN, OUT]) shouldShutDownElasticWorker() bool {
 	ws.stats.mu.Lock()
+	defer ws.stats.mu.Unlock()
 	if ws.stats.workerCount > ws.minWorkerSize && ws.stats.workerCount > ws.stats.jobsInFlight {
 		ws.stats.workerCount--
 		if ws.stats.jobsInFlight > 0 && ws.stats.workerCount == 0 {
 			ws.stats.workerCount++
-			ws.stats.mu.Unlock()
 			// prevents edge case that causes deadlock.
 			return false
 		}
-		ws.stats.mu.Unlock()
 		return true
 	}
-	ws.stats.mu.Unlock()
 	return false
 }
 

--- a/workers.go
+++ b/workers.go
@@ -155,25 +155,15 @@ func (ws *workerStation[IN, OUT]) runEnqueuer(ctx context.Context, in <-chan IN)
 		ws.wgJob.Add(1)
 
 		if ws.elasticWorkers {
-			//ws.stats.mu.Lock()
-			// if ws.stats.jobsInFlight > 0 && ws.stats.workerCount < ws.maxWorkerSize {
-			// 	if ws.stats.workerCount == 0 || ws.stats.workerCount < ws.stats.jobsInFlight {
-			// 		ws.stats.workerCount++
-			// 		ws.wgWorker.Go(func() {
-			// 			ws.startWorker(ctx)
-			// 		})
-			// 	}
-			// 	ws.stats.mu.Unlock()
-			// }
-			select {
-			case ws.queue <- job[IN]{val: inputValue, index: indexCounter}:
-				indexCounter++
-				continue
-			default:
-			}
-			// idea: ws.workerCount and ws.jobsInFlight should be part of a struct where they can both be mutex locked
+			// Scale up if there are more in-flight jobs than workers (and we're
+			// below the max). jobsInFlight was incremented under this same mutex
+			// in getInputValue before we got here, so this guarantees the
+			// invariant: whenever jobsInFlight >= 1, workerCount >= 1. Without
+			// this, a buffered send could deposit a job with no live worker to
+			// process it (notably with minWorkerSize=0), deadlocking on close.
+
 			ws.stats.mu.Lock()
-			if ws.stats.workerCount >= ws.minWorkerSize && ws.stats.workerCount < ws.maxWorkerSize {
+			if ws.stats.workerCount < ws.stats.jobsInFlight && ws.stats.workerCount < ws.maxWorkerSize {
 				ws.stats.workerCount++
 				ws.wgWorker.Go(func() {
 					ws.startWorker(ctx)

--- a/workers.go
+++ b/workers.go
@@ -111,8 +111,6 @@ type workerStation[IN, OUT any] struct {
 	wgWorker sync.WaitGroup
 	handler  HandlerFunc[IN, OUT]
 	stats    *workerStats
-	//workerCount  atomic.Int64
-	//jobsInFlight atomic.Int64
 }
 
 type workerStats struct {
@@ -235,6 +233,23 @@ func (ws *workerStation[IN, OUT]) wgJobFlush() {
 	}
 }
 
+func (ws *workerStation[IN, OUT]) shouldShutDownElasticWorker() bool {
+	ws.stats.mu.Lock()
+	if ws.stats.workerCount > ws.minWorkerSize && ws.stats.workerCount > ws.stats.jobsInFlight {
+		ws.stats.workerCount--
+		if ws.stats.jobsInFlight > 0 && ws.stats.workerCount == 0 {
+			ws.stats.workerCount++
+			ws.stats.mu.Unlock()
+			// prevents edge case that causes deadlock.
+			return false
+		}
+		ws.stats.mu.Unlock()
+		return true
+	}
+	ws.stats.mu.Unlock()
+	return false
+}
+
 // startWorker - starts a single worker to ingest the queue.
 func (ws *workerStation[IN, OUT]) startWorker(ctx context.Context) {
 	var tick <-chan time.Time
@@ -249,19 +264,9 @@ func (ws *workerStation[IN, OUT]) startWorker(ctx context.Context) {
 			ws.wgJobFlush()
 			return
 		case <-tick:
-			ws.stats.mu.Lock()
-			if ws.stats.workerCount > ws.minWorkerSize && ws.stats.workerCount > ws.stats.jobsInFlight {
-				ws.stats.workerCount--
-				if ws.stats.jobsInFlight > 0 && ws.stats.workerCount == 0 {
-					ws.stats.workerCount++
-					ws.stats.mu.Unlock()
-					// prevents edge case that causes deadlock.
-					continue
-				}
-				ws.stats.mu.Unlock()
+			if ws.shouldShutDownElasticWorker() {
 				return
 			}
-			ws.stats.mu.Unlock()
 			continue
 		case jobIn, ok = <-ws.queue:
 			if !ok {

--- a/workers.go
+++ b/workers.go
@@ -3,7 +3,6 @@ package gather
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -105,14 +104,21 @@ func newWorkerOpts(opts []Opt) *workerOpts {
 type workerStation[IN, OUT any] struct {
 	*workerOpts
 
-	queue        chan job[IN]
-	ordered      chan job[OUT]
-	out          chan OUT
-	wgJob        sync.WaitGroup
-	wgWorker     sync.WaitGroup
-	handler      HandlerFunc[IN, OUT]
-	workerCount  atomic.Int64
-	jobsInFlight atomic.Int64
+	queue    chan job[IN]
+	ordered  chan job[OUT]
+	out      chan OUT
+	wgJob    sync.WaitGroup
+	wgWorker sync.WaitGroup
+	handler  HandlerFunc[IN, OUT]
+	stats    *workerStats
+	//workerCount  atomic.Int64
+	//jobsInFlight atomic.Int64
+}
+
+type workerStats struct {
+	workerCount  int64
+	jobsInFlight int64
+	mu           sync.Mutex
 }
 
 // job - wraps around incoming and outgoing data (val) to track job metadata.
@@ -127,7 +133,10 @@ func (ws *workerStation[IN, OUT]) getInputValue(ctx context.Context, in <-chan I
 	select {
 	case v, ok := <-in:
 		if ok && ws.elasticWorkers {
-			ws.jobsInFlight.Add(1) // save cost of tracking if not elastic workers
+			// save cost of tracking if not elastic workers
+			ws.stats.mu.Lock()
+			ws.stats.jobsInFlight++
+			ws.stats.mu.Unlock()
 		}
 		return v, ok
 	case <-ctx.Done():
@@ -146,18 +155,31 @@ func (ws *workerStation[IN, OUT]) runEnqueuer(ctx context.Context, in <-chan IN)
 		ws.wgJob.Add(1)
 
 		if ws.elasticWorkers {
+			//ws.stats.mu.Lock()
+			// if ws.stats.jobsInFlight > 0 && ws.stats.workerCount < ws.maxWorkerSize {
+			// 	if ws.stats.workerCount == 0 || ws.stats.workerCount < ws.stats.jobsInFlight {
+			// 		ws.stats.workerCount++
+			// 		ws.wgWorker.Go(func() {
+			// 			ws.startWorker(ctx)
+			// 		})
+			// 	}
+			// 	ws.stats.mu.Unlock()
+			// }
 			select {
 			case ws.queue <- job[IN]{val: inputValue, index: indexCounter}:
 				indexCounter++
 				continue
 			default:
 			}
-			if workerCount := ws.workerCount.Load(); workerCount >= ws.minWorkerSize && workerCount < ws.maxWorkerSize {
+			// idea: ws.workerCount and ws.jobsInFlight should be part of a struct where they can both be mutex locked
+			ws.stats.mu.Lock()
+			if ws.stats.workerCount >= ws.minWorkerSize && ws.stats.workerCount < ws.maxWorkerSize {
+				ws.stats.workerCount++
 				ws.wgWorker.Go(func() {
 					ws.startWorker(ctx)
 				})
-				ws.workerCount.Add(1)
 			}
+			ws.stats.mu.Unlock()
 		}
 
 		select {
@@ -198,7 +220,9 @@ func (ws *workerStation[IN, OUT]) buildReenqueueFunc(ctx context.Context, index 
 func (ws *workerStation[IN, OUT]) sendResult(ctx context.Context, jobOut job[OUT], err error) {
 	defer ws.wgJob.Done()
 	if ws.elasticWorkers {
-		ws.jobsInFlight.Add(-1)
+		ws.stats.mu.Lock()
+		ws.stats.jobsInFlight--
+		ws.stats.mu.Unlock()
 	}
 	if ws.orderPreserved {
 		select {
@@ -235,18 +259,25 @@ func (ws *workerStation[IN, OUT]) startWorker(ctx context.Context) {
 			ws.wgJobFlush()
 			return
 		case <-tick:
-			if workerCount := ws.workerCount.Load(); workerCount > ws.minWorkerSize && workerCount > ws.jobsInFlight.Load() {
-				ws.workerCount.Add(-1)
-				if ws.jobsInFlight.Load() > 0 && ws.workerCount.CompareAndSwap(0, 1) {
+			ws.stats.mu.Lock()
+			if ws.stats.workerCount > ws.minWorkerSize && ws.stats.workerCount > ws.stats.jobsInFlight {
+				ws.stats.workerCount--
+				if ws.stats.jobsInFlight > 0 && ws.stats.workerCount == 0 {
+					ws.stats.workerCount++
+					ws.stats.mu.Unlock()
 					// prevents edge case that causes deadlock.
 					continue
 				}
+				ws.stats.mu.Unlock()
 				return
 			}
+			ws.stats.mu.Unlock()
 			continue
 		case jobIn, ok = <-ws.queue:
 			if !ok {
-				ws.workerCount.Add(-1)
+				ws.stats.mu.Lock()
+				ws.stats.workerCount--
+				ws.stats.mu.Unlock()
 				return
 			}
 		}
@@ -270,7 +301,9 @@ func (ws *workerStation[IN, OUT]) initWorkers(ctx context.Context) {
 			ws.startWorker(ctx)
 		})
 	}
-	ws.workerCount.Add(ws.minWorkerSize)
+	ws.stats.mu.Lock()
+	ws.stats.workerCount += ws.minWorkerSize
+	ws.stats.mu.Unlock()
 }
 
 // reorder - gate used to cache the result until the "next" result is cached and ready to be sent to out chan.
@@ -330,6 +363,7 @@ func Workers[IN any, OUT any](
 	ws := &workerStation[IN, OUT]{
 		workerOpts: newWorkerOpts(opts),
 		handler:    handler,
+		stats:      &workerStats{},
 	}
 	if err := ws.validate(); err != nil {
 		panic(err.Error())

--- a/workers_internal_test.go
+++ b/workers_internal_test.go
@@ -12,7 +12,9 @@ import (
 func TestWorkersSpawnAndImmediatelyCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ws := &workerStation[int, int]{}
+	ws := &workerStation[int, int]{
+		workerOpts: &workerOpts{},
+	}
 	ws.queue = make(chan job[int])
 	ws.out = make(chan int, 1)
 

--- a/workers_internal_test.go
+++ b/workers_internal_test.go
@@ -28,7 +28,7 @@ func TestWorkersSpawnAndImmediatelyCancel(t *testing.T) {
 
 	ws.wgJob.Add(1)
 	cancel()
-	ws.StartWorker(ctx)
+	ws.startWorker(ctx)
 	assert.Empty(t, ws.out)
 }
 
@@ -43,7 +43,7 @@ func TestReorder_CancelWhileBlockedOnOut(t *testing.T) {
 		ws := &workerStation[int, int]{out: out, ordered: ordered}
 
 		done := make(chan struct{})
-		go func() { ws.Reorder(ctx); close(done) }()
+		go func() { ws.reorder(ctx); close(done) }()
 
 		// send job to ordered chan but block from sending to out chan
 		ordered <- job[int]{val: 42, index: 0}

--- a/workers_test.go
+++ b/workers_test.go
@@ -553,10 +553,11 @@ func TestElasticWorkersLargeMinAndMaxWorkers(t *testing.T) {
 	jobs := 200
 	opts := []gather.Opt{
 		gather.WithBufferSize(3),
-		gather.WithWorkerSize(1000),
-		gather.WithElasticWorkers(999, 100*time.Microsecond),
+		gather.WithWorkerSize(180),
+		gather.WithElasticWorkers(179, 10*time.Microsecond),
 	}
-	out := gather.Workers(ctx, gen(ctx, jobs, 3), add(3), opts...)
+	mw := mwDelay[int, int](time.Microsecond)
+	out := gather.Workers(ctx, gen(ctx, jobs, 3), mw(add(3)), opts...)
 	var actual int
 	seen := make([]bool, jobs)
 	for v := range out {

--- a/workers_test.go
+++ b/workers_test.go
@@ -432,13 +432,137 @@ func TestWorkersChangeInputToNilThenCancel(t *testing.T) {
 			cancel()
 		}()
 		out := gather.Workers(ctx, in, add(3), gather.WithWorkerSize(3))
-		var expected int
+		var actual int
 		seen := make([]bool, 20)
 		for v := range out {
 			assert.False(t, seen[v-3])
 			seen[v-3] = true
-			expected++
+			actual++
 		}
-		assert.Equal(t, 20, expected)
+		assert.Equal(t, 20, actual)
 	})
+}
+
+// send jobs immediately (to scale up workers to max)
+// then stop long enough to scale down to min.
+func TestElasticWorkers(t *testing.T) {
+	// startingGoroutines := runtime.NumGoroutine()
+	minWorkers := 0
+	maxWorkers := 5
+	ctx := context.Background()
+	opts := []gather.Opt{
+		gather.WithWorkerSize(maxWorkers),
+		gather.WithElasticWorkers(minWorkers, 100*time.Microsecond),
+	}
+	in := make(chan int)
+	jobs := 200
+	go func() {
+		for i := range jobs {
+			in <- i
+			if i == 100 {
+				// TODO: replace this (non deterministic when running with parallel tests) with exported runtime metrics
+				// maxGoroutines := runtime.NumGoroutine()
+
+				// scale down to min workers
+				time.Sleep(time.Duration(maxWorkers-minWorkers+1) * 100 * time.Microsecond)
+
+				// the number of schedulers inside Workers (this design can change over time)
+				// minGoroutines := runtime.NumGoroutine()
+				// assert.Equal(t, maxWorkers-minWorkers, maxGoroutines-minGoroutines)
+			}
+		}
+		// should have scaled back up to max workers
+		close(in)
+	}()
+	// assert.Equal(t, startingGoroutines+1, runtime.NumGoroutine())
+	out := gather.Workers(ctx, in, add(3), opts...)
+	var actual int
+	seen := make([]bool, jobs)
+	for v := range out {
+		assert.False(t, seen[v-3])
+		seen[v-3] = true
+		actual++
+	}
+	assert.Equal(t, jobs, actual)
+}
+
+// attempt to scale down a second time but it will already be at min.
+func TestElasticWorkersUpDownDown(t *testing.T) {
+	minWorkers := 1
+	maxWorkers := 5
+	ctx := context.Background()
+	opts := []gather.Opt{
+		gather.WithWorkerSize(maxWorkers),
+		gather.WithElasticWorkers(minWorkers, 100*time.Microsecond),
+	}
+	in := make(chan int)
+	jobs := 200
+	go func() {
+		for i := range jobs {
+			in <- i
+			if i == 100 {
+				// scale down to min workers
+				time.Sleep(time.Duration(maxWorkers-minWorkers+1) * 100 * time.Microsecond)
+			}
+			if i == 101 {
+				// get the only worker to hit ttl but prevent from scaling down
+				time.Sleep(200 * time.Microsecond)
+			}
+		}
+		// should have scaled back up to max workers
+		close(in)
+	}()
+	out := gather.Workers(ctx, in, add(3), opts...)
+	var actual int
+	seen := make([]bool, jobs)
+	for v := range out {
+		assert.False(t, seen[v-3])
+		seen[v-3] = true
+		actual++
+	}
+	assert.Equal(t, jobs, actual)
+}
+
+func TestElasticWorkersSynchronousOrderedEarlyCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := []gather.Opt{
+		gather.WithWorkerSize(2),
+		gather.WithElasticWorkers(0, 10*time.Microsecond),
+		gather.WithOrderPreserved(),
+	}
+
+	in := make(chan int)
+	go func() {
+		in <- 0
+		cancel()
+	}()
+
+	var got int
+	for v := range gather.Workers(ctx, in, add(3), opts...) {
+		require.Equal(t, got+3, v)
+		got++
+	}
+	assert.LessOrEqual(t, got, 1)
+	// assert.Empty(t, got)
+}
+
+func TestElasticWorkersLargeMinAndMaxWorkers(t *testing.T) {
+	ctx := context.Background()
+	jobs := 200
+	opts := []gather.Opt{
+		gather.WithBufferSize(3),
+		gather.WithWorkerSize(1000),
+		gather.WithElasticWorkers(999, 100*time.Microsecond),
+	}
+	out := gather.Workers(ctx, gen(ctx, jobs, 3), add(3), opts...)
+	var actual int
+	seen := make([]bool, jobs)
+	for v := range out {
+		assert.False(t, seen[v-3])
+		seen[v-3] = true
+		actual++
+	}
+	assert.Equal(t, jobs, actual)
 }


### PR DESCRIPTION
## Summary
<!-- Required. What problem is this PR solving? -->

Implementing WithElasticWorkers
- allowing down to 0 min workers (for bursty loads)
- scale up instantly as needed
- scale down after worker is idle for ttl and no jobs in-flight
- make validate() method return an error for easier testing
  - will likely make another PR to have Workers return an error and also make a Must function to get just out chan

<strike-through>note: edge case that causes deadlock is not yet solved. Since I can't get back to this for a while:
the edge case: pipeline with 0 min workers, 1 max worker, 0 ttl, reorder gate, random delays on each job.
issue: rare occasions will deadlock due to timing of the last worker starting shut down > then a job is in-flight > worker is not shut down yet so no new worker is spawned > job gets stuck inifnitely in blocking select statement with no workers to receive it

possible solutions: 
- spawn a separate temporary goroutine for a short time to check for any incoming jobs
- preferred approach: track an atomic "last worker shutting down" variable so the enqueuer doesn't enter the blocking select statement yet </strike-through>

BEFORE MERGE:
set up and run regression tests to make sure performance doesn't take a hit when `WithElasticWorkers` is not used.

## Linked Issues
<!-- If applicable -->

TODO: get 100% test coverage